### PR TITLE
Get the RHCOS image from its new location

### DIFF
--- a/get_rhcos_image.sh
+++ b/get_rhcos_image.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-set -xe
+set -eu
+set -o pipefail
 
-source common.sh
+IMAGE_URL="$(curl --silent https://raw.githubusercontent.com/openshift/installer/master/data/data/rhcos.json | jq --raw-output '.baseURI + .images.openstack.path')"
 
-if [ ! -f "$RHCOS_IMAGE_FILENAME" ]; then
-    curl --insecure --compressed -L -o "${RHCOS_IMAGE_FILENAME}" "https://releases-redhat-coreos-dev.cloud.paas.upshift.redhat.com/storage/releases/maipo/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME}".gz
-fi
+echo "Downloading RHCOS image from:"
+echo "$IMAGE_URL"
+
+curl --insecure --compressed -L -O "$IMAGE_URL"


### PR DESCRIPTION
The images are now published under
https://releases-art-rhcos.svc.ci.openshift.org.

In addition, the OpenShift installer publishes the currently-supported
image under `data/data/rhcos.json`.

This commit updates the `get_rhcos_image.sh` script to download the
latest supported RHCOS image (by looking up the `rhcos.json` file on
GitHub).