### PR TITLE
Switch tripleo_cleanup.sh to podman

### DIFF
--- a/tripleo_cleanup.sh
+++ b/tripleo_cleanup.sh
@@ -2,19 +2,23 @@
 
 set -x
 
-sudo docker ps -aq | xargs sudo docker stop
-sudo docker ps -aq | xargs sudo docker rm -f
+sudo podman ps -aq | xargs --no-run-if-empty sudo podman stop
+sudo podman ps -aq | xargs --no-run-if-empty sudo podman rm -f
 
-sudo docker volume ls -q | xargs --no-run-if-empty sudo docker volume rm
+sudo podman volume ls -q | xargs --no-run-if-empty sudo podman volume rm
+sudo rm -Rf /var/lib/cinder
 sudo rm -Rf /var/lib/config-data
-sudo rm -Rf /var/lib/docker-puppet/
+sudo rm -Rf /var/lib/container-puppet
+sudo rm -Rf /var/lib/containers/storage/overlay
+sudo rm -Rf /var/lib/docker-puppet
 sudo rm -Rf /var/lib/glance
-sudo rm -Rf /var/lib/heat-config/*
+sudo rm -Rf /var/lib/heat*
 sudo rm -Rf /var/lib/kolla
 sudo rm -Rf /var/lib/mysql
 sudo rm -Rf /var/lib/neutron
 sudo rm -Rf /var/lib/nova
 sudo rm -Rf /var/lib/openstack
+sudo rm -Rf /var/lib/os-*
 sudo rm -Rf /var/lib/puppet
 sudo rm -Rf /var/lib/rabbitmq
 sudo rm -Rf /var/lib/tripleo


### PR DESCRIPTION
Now TripleO uses podman to manage containers, therefore current script's implementation doesn't work properly.
This commit switches tripleo_cleanup.sh to podman to make it workwith the latest TripleO versions.