### PR TITLE
Remove lolcat

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -13,8 +13,6 @@ sudo yum -y install epel-release
 sudo yum -y install curl vim-enhanced wget python-pip patch psmisc figlet golang
 sudo yum -y install https://dprince.fedorapeople.org/tmate-2.2.1-1.el7.centos.x86_64.rpm
 
-sudo pip install lolcat
-
 # for tripleo-repos install:
 sudo yum -y install python-setuptools python-requests
 
@@ -38,7 +36,7 @@ sudo tripleo-repos current-tripleo
 
 TRIPLEO_A=${TRIPLEO_VERSION:0:2}
 TRIPLEO_B=${TRIPLEO_VERSION:2:2}
-echo Pinned to tripleo version $TRIPLEO_A/$TRIPLEO_B/$TRIPLEO_VERSION | lolcat
+echo Pinned to tripleo version $TRIPLEO_A/$TRIPLEO_B/$TRIPLEO_VERSION | highlight
 sudo sed -i -e "{s@trunk.rdoproject.org/centos7/.*@trunk.rdoproject.org/centos7/$TRIPLEO_A/$TRIPLEO_B/$TRIPLEO_VERSION@}" /etc/yum.repos.d/delorean.repo
 
 sudo yum -y update
@@ -63,7 +61,7 @@ fi
 
 # Set hostname properly.
 HOSTNAME=`host $LOCAL_IP | cut -f 5 -d ' ' | sed s/.$//`
-echo $HOSTNAME | lolcat
+echo $HOSTNAME | highlight
 sudo hostnamectl set-hostname $HOSTNAME
 
 # We need this before tripleo now because octavia expects keys.

--- a/02_run_all_in_one.sh
+++ b/02_run_all_in_one.sh
@@ -50,7 +50,7 @@ parameter_defaults:
   $PARAMETERS_EXTRA
 EOF_CAT
 
-lolcat $SCRIPTDIR/standalone_parameters.yaml
+highlight $SCRIPTDIR/standalone_parameters.yaml
 
 sudo openstack tripleo deploy \
     --templates $SCRIPTDIR/tripleo-heat-templates \

--- a/03_configure_undercloud.sh
+++ b/03_configure_undercloud.sh
@@ -6,7 +6,7 @@ source common.sh
 # NOTE: this is the openstack admin section
 export OS_CLOUD=standalone
 
-openstack endpoint list | lolcat
+openstack endpoint list | highlight
 
 if ! openstack flavor show tiny; then
     openstack flavor create --ram 1024 --disk 10 --vcpu 2 --public tiny
@@ -54,10 +54,10 @@ if ! openstack image show amphora-image; then
 fi
 
 HOST_LOCALDOMAIN=`hostname -A | sed 's/ /\n/g' | grep localdomain`
-echo $HOST_LOCALDOMAIN | lolcat
+echo $HOST_LOCALDOMAIN | highlight
 neutron port-update --binding:host_id=$HOST_LOCALDOMAIN $(openstack port list -c ID -c Name | grep health | cut -f2 -d " ")
 
-echo To test: openstack loadbalancer create --vip-subnet-id public-subnet --name lb1 | lolcat
+echo To test: openstack loadbalancer create --vip-subnet-id public-subnet --name lb1 | highlight
 
 # Create a user without any admin priviledges
 if ! openstack project show openshift; then
@@ -121,7 +121,7 @@ Host $NETWORK.*
 EOF
 fi
 
-lolcat <<EOF
+highlight <<EOF
 Undercloud installed and configured.  To test:
 
 export OS_CLOUD=openshift

--- a/04_ocp_repo_sync.sh
+++ b/04_ocp_repo_sync.sh
@@ -4,11 +4,11 @@ set -ex
 source common.sh
 
 eval "$(go env)"
-echo "$GOPATH" | lolcat # should print $HOME/go or something like that
+echo "$GOPATH" | highlight # should print $HOME/go or something like that
 
 function sync_go_repo_and_patch {
     DEST="$GOPATH/src/$1"
-    figlet "Syncing $1" | lolcat
+    figlet "Syncing $1" | highlight
 
     if [ ! -d $DEST ]; then
         mkdir -p $DEST

--- a/05_build_ocp_installer.sh
+++ b/05_build_ocp_installer.sh
@@ -4,10 +4,10 @@ set -ex
 
 source common.sh
 
-figlet "Building the Installer" | lolcat
+figlet "Building the Installer" | highlight
 
 eval "$(go env)"
-echo "$GOPATH" | lolcat # should print $HOME/go or something like that
+echo "$GOPATH" | highlight # should print $HOME/go or something like that
 
 pushd "$GOPATH/src/github.com/openshift/installer"
 export MODE=dev

--- a/07_build_ci_operator.sh
+++ b/07_build_ci_operator.sh
@@ -5,7 +5,7 @@ set -ex
 source common.sh
 
 eval "$(go env)"
-echo "$GOPATH" | lolcat
+echo "$GOPATH" | highlight
 
 
 pushd "$GOPATH/src/github.com/openshift/ci-operator"

--- a/common.sh
+++ b/common.sh
@@ -30,3 +30,23 @@ export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="registry.svc.ci.openshift.org/o
 # You can get the latest hash here:
 # https://trunk.rdoproject.org/centos7/current-tripleo/commit.yaml
 TRIPLEO_VERSION='25698ebfff692178450478b5207b09ca99d277b2_aba8ec54'
+
+# Use some color to highlight actionable output
+highlight() {
+    set +x
+
+    local IFS
+    local set_bold
+    local reset
+
+    set_bold="$(tput setaf 3)$(tput bold)"
+    reset="$(tput sgr0)"
+
+    set -- "${1:-/dev/stdin}" "${@:2}"
+
+    for f in "$@"; do
+        while read -r line; do
+            printf "%s%s%s\n" "$set_bold" "$line" "$reset"
+        done < "$f"
+    done
+}

--- a/expose_ocp_api.sh
+++ b/expose_ocp_api.sh
@@ -12,7 +12,7 @@ source common.sh
 
 LB_FLOATING_IP=$(openstack server show ${CLUSTER_NAME}-api -f value -c addresses | cut -d " " -f 2)
 
-echo "Attempting to expose cluster's API on floating IP: ${LB_FLOATING_IP}" | lolcat
+echo "Attempting to expose cluster's API on floating IP: ${LB_FLOATING_IP}" | highlight
 
 if ! grep -q ${LB_FLOATING_IP} /etc/hosts ; then
     (echo "${LB_FLOATING_IP} api.${CLUSTER_NAME}.shiftstack.com" && grep -v "api.${CLUSTER_NAME}.shiftstack.com" /etc/hosts) | sudo tee /etc/hosts

--- a/install_docker_registry.sh
+++ b/install_docker_registry.sh
@@ -5,7 +5,7 @@ set -ex
 source common.sh
 
 eval "$(go env)"
-echo "$GOPATH" | lolcat
+echo "$GOPATH" | highlight
 
 if [ "$(cat /proc/sys/user/max_user_namespaces)" = "0" ]; then
 	echo 10000 | sudo tee /proc/sys/user/max_user_namespaces
@@ -17,7 +17,7 @@ if ! grep -q $USER /etc/subgid ; then
 	echo $USER:10000:65536 | sudo tee -a /etc/subgid
 fi
 
-figlet "Run docker registry" | lolcat
+figlet "Run docker registry" | highlight
 
 OVERRIDE_IMAGES=""
 sudo podman rm -f registry || true


### PR DESCRIPTION
As of the latest release, lolcat requires Python 2.7.16. Unfortunately,
CentOS only provides Python 2.5.

This PR introduces a `highlight` Bash function in common.sh, that will
highlight the output, only slightly less unicornishly.