### PR TITLE
Handle compress vm image files and added documentation

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -xe
+set -x
 
 source common.sh
 
@@ -11,9 +11,8 @@ sudo yum -y update
 
 sudo yum -y install epel-release
 sudo yum -y install curl vim-enhanced wget python-pip patch psmisc figlet golang
-set +e
 sudo yum -y install https://dprince.fedorapeople.org/tmate-2.2.1-1.el7.centos.x86_64.rpm
-set -e
+
 # for tripleo-repos install:
 sudo yum -y install python-setuptools python-requests
 

--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -x
+set -xe
 
 source common.sh
 
@@ -11,8 +11,9 @@ sudo yum -y update
 
 sudo yum -y install epel-release
 sudo yum -y install curl vim-enhanced wget python-pip patch psmisc figlet golang
+set +e
 sudo yum -y install https://dprince.fedorapeople.org/tmate-2.2.1-1.el7.centos.x86_64.rpm
-
+set -e
 # for tripleo-repos install:
 sudo yum -y install python-setuptools python-requests
 

--- a/03_configure_undercloud.sh
+++ b/03_configure_undercloud.sh
@@ -38,7 +38,7 @@ if ! openstack image show cirros; then
     openstack image create cirros --container-format bare --disk-format qcow2 --public --file "$CIRROS_IMAGE_FILENAME"
 fi
 
-./get-rhcos-image.sh
+./get-rhcos-image.sh $RHCOS_IMAGE_FILENAME
 RHOS_IMAGE_HASH=$(sha512sum $RHCOS_IMAGE_FILENAME | awk '{print $1}')
 if ! openstack image show rhcos; then
     openstack image create rhcos --container-format bare --disk-format qcow2 --public --file $RHCOS_IMAGE_FILENAME

--- a/README.md
+++ b/README.md
@@ -9,6 +9,74 @@ OpenShift Installer OpenStack Dev Scripts
 
 # Instructions
 
+## 0) Pre installation
+
+Enable the appropriate openstack repo. 
+From the output of 
+
+ `sudo yum search release-openstack`
+
+install the desired repositories for the release you want to use. For example: 
+
+ `sudo yum install centos-release-openstack-rocky`
+
+Install openstack client
+
+`sudo yum install python2-openstackclient`
+
+Install git
+
+`sudo yum install git`
+
+Configure stack user to use ansible <2.9 (2.9 does not support he "failed" filter).
+We have to do it at the root level because some of the playbooks apperantly are run 
+under root, so just changing it at the user level will not work. 
+
+`sudo pip uninstall ansible`
+
+`sudo pip install "ansible==2.8.7"`
+
+Then verify that you ansible version is 2.8.7
+
+`ansible --version`
+
+Clone this repository:
+
+`cd <to_wherever_you_want_this_source_code_to_live`
+
+`git clone <this repos address>`
+
+
+CD to repo
+
+`cd ocp-doit`
+
+Get the lastest artifacts hash for the tripleo  if you want to use it, and set it in common.sh
+you can get it from:
+
+` https://trunk.rdoproject.org/centos7/current-tripleo/commit.yaml`
+
+by joining the `commit_hash` with the first 8 characters of the `distro_hash` with a `_`. 
+For example:
+ 
+    commit_hash: 38c4e3104abdeb4699cfbe7a78fa2f37d7a863b4
+    distgit_dir: /home/centos-master-uc/data/puppet-manila_distro/
+    distro_hash: 93bde36c78d20a482068674c1391725cdf89b6d9
+
+then the hash becomes:
+
+`38c4e3104abdeb4699cfbe7a78fa2f37d7a863b4_93bde36c`
+
+Install and configure a dns server on the host machine (The machine with the LOCAL_IP address).  The LOCAL_IP
+address is used as the dns server for the host as well as the forwarder for the Neutron dnsmasq and other dns services. 
+
+example /etc/dnsmasq.conf
+
+    domain-needed
+    bogus-priv
+    server=192.168.122.1
+    conf-dir=/etc/dnsmasq.d,.rpmnew,.rpmsave,.rpmo
+    
 ## 1) Create local config
 
 Create a config file based on the example and set values appropriate for your

--- a/README.md
+++ b/README.md
@@ -11,16 +11,15 @@ OpenShift Installer OpenStack Dev Scripts
 
 ## 0) Pre installation
 
-Enable the appropriate openstack repo. 
-From the output of 
+Enable the appropriate openstack repo, by looking at the output of
 
  `sudo yum search release-openstack`
 
-install the desired repositories for the release you want to use. For example: 
+and installing the desired repositories for the release you want to use. For example:
 
  `sudo yum install centos-release-openstack-rocky`
 
-Install openstack client
+Install OpenStack client
 
 `sudo yum install python2-openstackclient`
 
@@ -28,15 +27,16 @@ Install git
 
 `sudo yum install git`
 
-Configure stack user to use ansible <2.9 (2.9 does not support he "failed" filter).
-We have to do it at the root level because some of the playbooks apperantly are run 
-under root, so just changing it at the user level will not work. 
+Configure stack user to use the correct version of ansible.
+
+For example, 2.9 does not support the "failed" filter, so you might have to switch to a lower version.
+
+Do it at the root level because some of the playbooks run
+under root, so just changing it at the user level will not be enough.
 
 `sudo pip uninstall ansible`
 
 `sudo pip install "ansible==2.8.7"`
-
-Then verify that you ansible version is 2.8.7
 
 `ansible --version`
 
@@ -51,32 +51,36 @@ CD to repo
 
 `cd ocp-doit`
 
-Get the lastest artifacts hash for the tripleo  if you want to use it, and set it in common.sh
-you can get it from:
+Get the lastest artifacts hash for the tripleo  if you want to use it, and set it in common.sh.
+You can get it from:
 
 ` https://trunk.rdoproject.org/centos7/current-tripleo/commit.yaml`
 
-by joining the `commit_hash` with the first 8 characters of the `distro_hash` with a `_`. 
+by joining the `commit_hash` and the first 8 characters of the `distro_hash` with a `_`.
 For example:
  
     commit_hash: 38c4e3104abdeb4699cfbe7a78fa2f37d7a863b4
     distgit_dir: /home/centos-master-uc/data/puppet-manila_distro/
     distro_hash: 93bde36c78d20a482068674c1391725cdf89b6d9
 
-then the hash becomes:
+becomes:
 
 `38c4e3104abdeb4699cfbe7a78fa2f37d7a863b4_93bde36c`
 
 Install and configure a dns server on the host machine (The machine with the LOCAL_IP address).  The LOCAL_IP
-address is used as the dns server for the host as well as the forwarder for the Neutron dnsmasq and other dns services. 
+address is used as the forwarder for the Neutron dnsmasq and other dns services.
 
-example /etc/dnsmasq.conf
+Dnsmasq is probably a good enough solution.
+
+Example of /etc/dnsmasq.conf on LOCAL_IP machine, which makes machine use 192.168.122.1 as a forwarder
 
     domain-needed
     bogus-priv
     server=192.168.122.1
     conf-dir=/etc/dnsmasq.d,.rpmnew,.rpmsave,.rpmo
-    
+
+Now the LOCAL_IP machine will respond to DNS queries using dnsmasq, and it will forward  requests to 192.168.122.1 if needed.
+
 ## 1) Create local config
 
 Create a config file based on the example and set values appropriate for your

--- a/common.sh
+++ b/common.sh
@@ -29,7 +29,7 @@ export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="registry.svc.ci.openshift.org/o
 # We'll have to check once in a while for a new version though.
 # You can get the latest hash here:
 # https://trunk.rdoproject.org/centos7/current-tripleo/commit.yaml
-TRIPLEO_VERSION='25698ebfff692178450478b5207b09ca99d277b2_aba8ec54'
+TRIPLEO_VERSION='38c4e3104abdeb4699cfbe7a78fa2f37d7a863b4_93bde36c'
 
 # Use some color to highlight actionable output
 highlight() {

--- a/get-rhcos-image.sh
+++ b/get-rhcos-image.sh
@@ -13,6 +13,8 @@ IMAGE_NAME=$(echo "${IMAGE_URL##*/}")
 
 gzip -l $IMAGE_NAME >/dev/null 2>&1
 
+# Lets check to see if file is compressed with gzip
+# and uncompress it if so
 if [[ $? -eq 0 ]]
 then
    echo "$IMAGE_NAME is compressed. Expanding..."
@@ -20,7 +22,7 @@ then
    IMAGE_NAME="${IMAGE_NAME%.gz}"
 fi
 
-
+# Save image with user specified name.
 if [ "$#" -eq 1 ]
 then
    mv $IMAGE_NAME ${1}

--- a/get-rhcos-image.sh
+++ b/get-rhcos-image.sh
@@ -8,3 +8,22 @@ echo "Downloading RHCOS image from:"
 echo "$IMAGE_URL"
 
 curl --insecure --compressed -L -O "$IMAGE_URL"
+
+IMAGE_NAME=$(echo "${IMAGE_URL##*/}")
+
+gzip -l $IMAGE_NAME >/dev/null 2>&1
+
+if [[ $? -eq 0 ]]
+then
+   echo "$IMAGE_NAME is compressed. Expanding..."
+   gunzip -f $IMAGE_NAME
+   IMAGE_NAME="${IMAGE_NAME%.gz}"
+fi
+
+
+if [ "$#" -eq 1 ]
+then
+   mv $IMAGE_NAME ${1}
+   IMAGE_NAME=${1}
+fi
+echo File saved as $IMAGE_NAME


### PR DESCRIPTION
The files used for the vm images are now gzipped, thus the script needs to uncompressed the files before creating the glance image. 

Added some more details on the documentation about getting the local machine ready for installation. 